### PR TITLE
Add bucket for 1xx responses

### DIFF
--- a/milliseconds.py
+++ b/milliseconds.py
@@ -59,6 +59,7 @@ result = {
     'cache_hit': dict(bucket),
     'cache_miss': dict(bucket),
     'cache_other': dict(bucket),
+    '1xx': dict(bucket),
     '2xx': dict(bucket),
     '3xx': dict(bucket),
     '4xx': dict(bucket),


### PR DESCRIPTION
Add bucket for fairly rare 1xx responses.

Right now the script will crash whenever it encounters one while parsing the logs