### PR TITLE
Modify request type to accept '-' character

### DIFF
--- a/milliseconds.py
+++ b/milliseconds.py
@@ -86,7 +86,7 @@ lineformat = (
     r'(?P<remote_user>[^\[]+) '
     r'\[(?P<time>.+)\] '
     # Clients can name their methods whatever, e.g. CCM_POST
-    r'"(?P<request_type>[A-Z_]+) '
+    r'"(?P<request_type>[A-Z_-]+) '
     r'(?P<request_url>[^"]+) '
     r'(?P<protocol>[^ ]+)" '
     r'(?P<status>[0-9]+) '


### PR DESCRIPTION
There are some rare request types that contain the character '-', such as `BASELINE-CONTROL`. Encountering such at the moment crashes the script.